### PR TITLE
feat[add-record]: implement navigation to add-record component from records page

### DIFF
--- a/src/app/material.module.ts
+++ b/src/app/material.module.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
@@ -19,7 +20,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     MatTooltipModule,
     MatDialogModule,
     MatButtonModule,
-    MatProgressBarModule
+    MatProgressBarModule,
+    MatIconModule
   ],
   exports: [
     MatCardModule,
@@ -27,7 +29,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     MatTooltipModule,
     MatDialogModule,
     MatButtonModule,
-    MatProgressBarModule
+    MatProgressBarModule,
+    MatIconModule
   ]
 })
 export class MaterialModule { }

--- a/src/app/records/components/records/records.component.html
+++ b/src/app/records/components/records/records.component.html
@@ -1,14 +1,21 @@
-<div class="records-container"
-  [ngClass]="{'light-grey-bg': thoughtRecords.length }">
-  <ng-container *ngIf="thoughtRecords?.length; else noRecords ">
-    <a *ngFor="let record of thoughtRecords"
-      routerLink="records/{{record.id}}">
-      <app-record-card [thoughtRecord]="record"></app-record-card>
+<div class="page-container">
+  <div class="toolbar-container">
+    <a routerLink="add-record">
+      <mat-icon [color]="'warning'">add</mat-icon>
     </a>
-  </ng-container>
-  <ng-template #noRecords>
-    <div class="no-records">
-      <p class="mat-body-1">No thought record found.</p>
-    </div>
-  </ng-template>
+  </div>
+  <div class="records-container"
+    [ngClass]="{'light-grey-bg': thoughtRecords.length }">
+    <ng-container *ngIf="thoughtRecords?.length; else noRecords ">
+      <a *ngFor="let record of thoughtRecords"
+        routerLink="records/{{record.id}}">
+        <app-record-card [thoughtRecord]="record"></app-record-card>
+      </a>
+    </ng-container>
+    <ng-template #noRecords>
+      <div class="no-records">
+        <p class="mat-body-1">No thought record found.</p>
+      </div>
+    </ng-template>
+  </div>
 </div>

--- a/src/app/records/components/records/records.component.scss
+++ b/src/app/records/components/records/records.component.scss
@@ -1,15 +1,20 @@
+.page-container {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+}
+
 .records-container {
-  width: 100%;
+  width: 85%;
   min-height: 20rem;
   max-height: 29.9rem;
-  margin: auto;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   gap: 1em; 
   overflow-y: auto;
   overflow-x: hidden;
-  padding-bottom: 1rem;
+  padding: 0rem 2rem 2rem 1rem;
 }
 
 .no-records {

--- a/src/app/records/components/view-record/view-record.component.scss
+++ b/src/app/records/components/view-record/view-record.component.scss
@@ -10,7 +10,7 @@
 }
 
 .back {
-  padding-top: 2rem;
+  padding-top: 0.6rem;
   padding-left: 0.5rem;
   color: #5f6368;
 
@@ -20,7 +20,7 @@
 }
 
 .view-record {
-  padding: 1.5rem 2rem 2rem 1rem;
+  padding: 0 2rem 2rem 1rem;
   width: 80%;
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Why?
- allow the user to navigate to add-record component to be able to  start adding a record

## How?
- added through a tag with plus icon

## Testing?

<img width="1168" alt="Screenshot 2023-10-17 at 09 00 24" src="https://github.com/theresecodes/thought-record/assets/44773843/f572668e-46c3-4c18-9d26-7f642587bacd">
