### PR TITLE
fix[add-emotion]: on done adding emotion step

### DIFF
--- a/src/app/records/components/add-emotions/add-emotions.component.html
+++ b/src/app/records/components/add-emotions/add-emotions.component.html
@@ -102,9 +102,9 @@
     <div body class="yes-no-container mt-4">
       <p>{{ identifiedEmotion }}</p>
       <button mat-raised-button color="primary" class="card-btn"
-       (click)="proceedToNextAddEmotionStep(addEmotionStep.SELECT_CORE)">Yes</button>
+       (click)="proceedToNextAddEmotionStep(addEmotionStep.EXIT)">Yes</button>
        <button mat-raised-button color="warn" class="card-btn"
-       (click)="proceedToNextAddEmotionStep(addEmotionStep.DONE_ADDING_EMOTION)">No</button>
+       (click)="proceedToNextAddEmotionStep(addEmotionStep.SELECT_CORE)">No</button>
     </div>
   </app-step>
 </ng-template>

--- a/src/app/records/components/add-record/add-record.component.html
+++ b/src/app/records/components/add-record/add-record.component.html
@@ -1,19 +1,7 @@
 {{ step }}
 <ng-container [ngSwitch]="step">
-  <app-add-emotions 
-    *ngSwitchCase="addRecordStep.ADD_EMOTION"
-    (done)="proceedToNextStep(addRecordStep.ADD_SITUATION)">
-  </app-add-emotions>
-  <app-add-situation 
-    *ngSwitchCase="addRecordStep.ADD_SITUATION"
-    (done)="proceedToNextStep(addRecordStep.ADD_THOUGHTS)">
-  </app-add-situation>
-  <app-add-thoughts
-    *ngSwitchCase="addRecordStep.ADD_THOUGHTS"
-    (done)="proceedToNextStep(addRecordStep.ADD_TITLE)">
-  </app-add-thoughts>
-  <app-add-title
-    *ngSwitchCase="addRecordStep.ADD_TITLE"
-    (done)="proceedToNextStep(addRecordStep.EXIT)">
-  </app-add-title>
+  <app-add-emotions *ngSwitchCase="addRecordStep.ADD_EMOTION" (done)="proceedToNextStep(addRecordStep.ADD_SITUATION)"></app-add-emotions>
+  <app-add-situation *ngSwitchCase="addRecordStep.ADD_SITUATION" (done)="proceedToNextStep(addRecordStep.ADD_THOUGHTS)"></app-add-situation>
+  <app-add-thoughts *ngSwitchCase="addRecordStep.ADD_THOUGHTS" (done)="proceedToNextStep(addRecordStep.ADD_TITLE)"></app-add-thoughts>
+  <app-add-title *ngSwitchCase="addRecordStep.ADD_TITLE" (done)="proceedToNextStep(addRecordStep.EXIT)"></app-add-title>
 </ng-container>


### PR DESCRIPTION
## What?
- On done adding emotion step, clicking yes goes back to core selection instead of proceeding to add situation ui

## Why?
- incorrect `proceedToNextAddEmotionStep` argument for yes

## Testing?
- manually tested as working again
